### PR TITLE
Add one space in formatting. Configure production.rb for image asset

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@ a {
 .search-submit {
   background-color: #bacc81;
 }
+
 .search-submit:hover {
   background-color:#FEDE00;
 }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
- Config settings changed to allow heroku to use background image in assets